### PR TITLE
feat: add button to toggle watch and reload

### DIFF
--- a/support.js
+++ b/support.js
@@ -1,7 +1,15 @@
 /// <reference types="Cypress" />
 
+const insertToggleButton = require('./ui/toggle-btn')
 const waitUntil = require('async-wait-until')
 const ws = new WebSocket('ws://localhost:8765')
+
+let watchAndReloadEnabled = true
+const button = insertToggleButton()
+button.onclick = () => {
+  button.classList.toggle("auto-scrolling-enabled")
+  watchAndReloadEnabled = !watchAndReloadEnabled
+}
 
 beforeEach(() => {
   cy.wrap(
@@ -15,11 +23,13 @@ beforeEach(() => {
         try {
           const data = JSON.parse(ev.data)
           if (data.command === 'reload' && data.filename) {
-            console.log(
-              'reloading Cypress because "%s" has changed',
-              data.filename
-            )
-            window.top.document.querySelector('.reporter .restart').click()
+            if (watchAndReloadEnabled) {
+              console.log(
+                'reloading Cypress because "%s" has changed',
+                data.filename
+              )
+              window.top.document.querySelector('.reporter .restart').click()
+            }
           }
         } catch (e) {
           console.error('Could not parse message from plugin')

--- a/ui/toggle-btn.js
+++ b/ui/toggle-btn.js
@@ -1,0 +1,24 @@
+function insertToggleButton() {
+  const doc = window.top.document
+
+  let existing = doc.querySelector('#cypress-watch-and-reload-toggle')
+  if (existing) {
+    existing.remove()
+  }
+
+  const controls = doc.querySelector('.controls')
+  const span = doc.createElement('span')
+  span.id = 'cypress-watch-and-reload-toggle'
+  // reuse existing classes for simplicity
+  span.innerHTML = `
+    <button title="Toggle watch and reload" class="toggle-auto-scrolling auto-scrolling-enabled">
+      <i style="color: #8bc34a"></i>
+      <i class="fas fa-eye"></i>
+    </button>
+  `
+  controls.prepend(span)
+
+  return span.querySelector('button')
+}
+
+module.exports = insertToggleButton


### PR DESCRIPTION
closes #118 

This PR adds a button to toggle reloading the tests when the watched files change

<img width="242" alt="2021-08-02 at 2 09 PM" src="https://user-images.githubusercontent.com/793712/127867189-fbc504df-a8a6-4b27-bd2b-c2e688629421.png">

It's useful when making small adjustments during TDD

I reused existing classes `toggle-auto-scrolling` and `auto-scrolling-enabled` to keep the html as simple as possible