### PR TITLE
fix: reload tab if restart button is not available

### DIFF
--- a/support.js
+++ b/support.js
@@ -35,7 +35,8 @@ if (Cypress.config('isInteractive')) {
                   'reloading Cypress because "%s" has changed',
                   data.filename,
                 )
-                window.top.document.querySelector('.reporter .restart').click()
+                const restartBtn = window.top.document.querySelector('.reporter .restart')
+                restartBtn ? restartBtn.click() : window.top.location.reload()
               }
             }
           } catch (e) {


### PR DESCRIPTION
Fixes #147

The restart button is replaced by the stop button when the test is running which results in an error.
This fix reloads the tab when there is no restart btn