### PR TITLE
feat: use dynamic port allocation to support multiple plugin instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,19 @@ Note: this plugin will work if you pass both `on` and `config` arguments, or jus
 
 ```js
 // pass both arguments
-require('cypress-watch-and-reload/plugins')(on, config)
+await require('cypress-watch-and-reload/plugins')(on, config)
 // or pass just the config object
-require('cypress-watch-and-reload/plugins')(config)
+await require('cypress-watch-and-reload/plugins')(config)
+```
+
+Note: The plugin returns a Promise. Use `await` if not directly returning from `setupNodeEvents`:
+
+```js
+async setupNodeEvents(on, config) {
+  await require('cypress-watch-and-reload/plugins')(on, config)
+  // do other setup...
+  return config
+}
 ```
 
 **Important:** make sure to return the plugin registration or the `config` object
@@ -66,8 +76,8 @@ setupNodeEvents(on, config) {
   return require('cypress-watch-and-reload/plugins')(on, config)
 }
 // or return the config object
-setupNodeEvents(on, config) {
-  require('cypress-watch-and-reload/plugins')(on, config)
+async setupNodeEvents(on, config) {
+  await require('cypress-watch-and-reload/plugins')(on, config)
   return config
 }
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "async-wait-until": "1.2.6",
         "chokidar": "3.6.0",
+        "get-port": "5.1.1",
         "ws": "8.18.3"
       },
       "devDependencies": {
@@ -2073,6 +2074,18 @@
       "dev": true,
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-port": {
+      "version": "5.1.1",
+      "resolved": "https://global.block-artifacts.com/artifactory/api/npm/square-npm/get-port/-/get-port-5.1.1.tgz",
+      "integrity": "sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-stream": {
@@ -9481,6 +9494,11 @@
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true
+    },
+    "get-port": {
+      "version": "5.1.1",
+      "resolved": "https://global.block-artifacts.com/artifactory/api/npm/square-npm/get-port/-/get-port-5.1.1.tgz",
+      "integrity": "sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ=="
     },
     "get-stream": {
       "version": "5.2.0",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "async-wait-until": "1.2.6",
     "chokidar": "3.6.0",
+    "get-port": "5.1.1",
     "ws": "8.18.3"
   },
   "devDependencies": {

--- a/plugins.js
+++ b/plugins.js
@@ -22,7 +22,6 @@ module.exports = async (on, config) => {
   // create socket even if not watching files to avoid
   // tripping up client trying to connect
   const port = await getPort({ port: 8765 })
-  console.log(`cypress-watch-and-reload: using port ${port}`)
   const wss = new WebSocket.Server({ port })
   let client // future Cypress client
 

--- a/plugins.js
+++ b/plugins.js
@@ -1,7 +1,8 @@
 const WebSocket = require('ws')
 const chokidar = require('chokidar')
+const getPort = require('get-port')
 
-module.exports = (on, config) => {
+module.exports = async (on, config) => {
   // sometimes the users might pass both arguments
   // require('cypress-watch-and-reload')(on, config)
   // or just the config
@@ -20,7 +21,9 @@ module.exports = (on, config) => {
   // https://github.com/websockets/ws#simple-server
   // create socket even if not watching files to avoid
   // tripping up client trying to connect
-  const wss = new WebSocket.Server({ port: 8765 })
+  const port = await getPort({ port: 8765 })
+  console.log(`cypress-watch-and-reload: using port ${port}`)
+  const wss = new WebSocket.Server({ port })
   let client // future Cypress client
 
   const env = config.env || {}
@@ -85,5 +88,6 @@ module.exports = (on, config) => {
     config.env = {}
   }
   config.env.cypressWatchAndReloadPluginInitialized = true
+  config.env.cypressWatchAndReloadPort = port
   return config
 }

--- a/support.js
+++ b/support.js
@@ -3,7 +3,8 @@
 if (Cypress.config('isInteractive')) {
   const insertToggleButton = require('./ui/toggle-btn')
   const waitUntil = require('async-wait-until')
-  const ws = new WebSocket('ws://localhost:8765')
+  const port = Cypress.env('cypressWatchAndReloadPort')
+  const ws = new WebSocket(`ws://localhost:${port}`)
 
   let watchAndReloadEnabled = true
   const button = insertToggleButton()


### PR DESCRIPTION
## Summary
Replaces the hardcoded port 8765 with a dynamic port so multiple instances of cypress-watch-and-reload can run at a time. Fixes #207.

## Preview
![2025-07-31 10 44 45](https://github.com/user-attachments/assets/f8a3b2f5-0e7a-4ff7-8e49-c93912da1017)

We can also see they are connecting back on different ports:
<img width="1360" height="523" alt="image" src="https://github.com/user-attachments/assets/5031cea2-b7ca-4b80-805f-777c2375dfc4" />
